### PR TITLE
Add Intact.Simulation for nTop connector package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.exe filter=lfs diff=lfs merge=lfs -text
+*.msi filter=lfs diff=lfs merge=lfs -text

--- a/packages/IntactSimulation/intact-simulation-for-ntop/README.md
+++ b/packages/IntactSimulation/intact-simulation-for-ntop/README.md
@@ -1,0 +1,38 @@
+# Intact.Simulation for nTop
+
+The Intact.Simulation for nTop connector brings no-preprocessing FEA directly into the nTop design environment. It is built to analyze complex implicit geometry without requiring FEA meshing, geometry cleanup, or model simplification.
+
+## Key capabilities
+
+- Directly simulates implicits without conversion to a surface mesh.
+- Supports structural, thermal, and modal analysis for designs that are difficult to prepare with traditional FEA.
+- Enables both quick design checks and higher-fidelity evaluations as the design matures.
+- Supports automated design studies and DOE-style exploration through fast, repeatable analysis setup.
+- Works naturally with nTop's field-driven design workflows, helping users evaluate and iterate on lightweighting concepts.
+- Can connect with nTop fluid results for fluid-structure interaction studies for aero structures and heat exchangers.
+
+## Installation
+
+Run the provided installer:
+
+```
+intact-simulation-for-ntop-installer-2.0.1-37.exe
+```
+
+Example files are included in the installer and can be found at:
+
+```
+%APPDATA%\Local\Programs\Intact.Simulation for nTop\Getting Started
+```
+
+See the [Getting Started](https://www.intactsimulation.com/ntop) page for examples and more information.
+
+## Licensing
+
+- **Trial license:** Visit the [Intact.Simulation for nTop page](https://www.intactsimulation.com/ntop) to submit a trial request.
+- **Purchase a license:** Use the pricing section on the same page to complete a transaction online.
+- **Custom or enterprise licensing:** [Contact the Intact sales team](https://www.notion.so/p/284f7e542d2180a88f47fdc94fd860eb) for custom licensing, enterprise needs, or additional questions.
+
+## License
+
+Proprietary - license granted via installer.

--- a/packages/IntactSimulation/intact-simulation-for-ntop/intact-simulation-for-ntop-installer-2.0.1-37.exe
+++ b/packages/IntactSimulation/intact-simulation-for-ntop/intact-simulation-for-ntop-installer-2.0.1-37.exe
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e3eedaa7b9b22ef989c3b4ec020d175b5a91048e63f4162c781ff5642488a9af
+size 232848056

--- a/packages/IntactSimulation/intact-simulation-for-ntop/manifest.json
+++ b/packages/IntactSimulation/intact-simulation-for-ntop/manifest.json
@@ -1,0 +1,16 @@
+{
+  "id": "intact-simulation-for-ntop",
+  "type": "Connector",
+  "title": "Intact.Simulation for nTop",
+  "summary": "No-preprocessing FEA connector that simulates complex implicit geometry directly in nTop without meshing, geometry cleanup, or model simplification.",
+  "author": "IntactSimulation",
+  "org": "Intact.Simulation",
+  "version": "2.0.1",
+  "ntopVersion": "5.48+",
+  "license": "Proprietary",
+  "domain": "Simulation",
+  "application": "FEA/CFD",
+  "complexity": "Intermediate",
+  "tags": ["fea", "structural", "thermal", "modal", "implicit", "meshless", "simulation"],
+  "preview": "bundle"
+}


### PR DESCRIPTION
## Summary

- Adds `packages/IntactSimulation/intact-simulation-for-ntop/` connector package
- No-preprocessing FEA connector supporting structural, thermal, and modal analysis directly on nTop implicit geometry
- Includes installer (v2.0.1), manifest, and README with licensing and getting started info
- Configures Git LFS to track `*.exe` and `*.msi` files

## Test plan

- [x] Verify manifest validates against schema (`node scripts/validate-manifests.js`)
- [x] Check README renders correctly on the detail page
- [x] Confirm LFS-tracked installer is accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)