### PR TITLE
Fix sync-to-private workflow to work with fork PRs

### DIFF
--- a/.github/workflows/sync-to-private.yml
+++ b/.github/workflows/sync-to-private.yml
@@ -9,7 +9,11 @@ name: Sync approved submissions to private repo
 #                         permissions: Contents: read & write, Pull requests: read & write.
 
 on:
-  pull_request:
+  # pull_request_target (not pull_request) so PRs from forks still get
+  # PRIVATE_REPO_TOKEN - GitHub withholds secrets from plain `pull_request`
+  # runs triggered by a fork. Safe here because the job only runs post-merge
+  # and never executes code from the fork branch itself.
+  pull_request_target:
     types: [closed]
     branches: [main]
 


### PR DESCRIPTION
## Summary
- PR #10 (from fork \`intact-solutions/Utilities-community\`) merged but never synced to the private repo.
- Root cause: \`sync-to-private.yml\` triggers on \`pull_request\`, and GitHub withholds repo secrets from \`pull_request\` runs triggered by a fork. \`PRIVATE_REPO_TOKEN\` came through empty, and the private-repo checkout step failed with \`Input required and not supplied: token\`.
- Fix: switch the trigger to \`pull_request_target\`, which does get secrets. Safe here since the job only runs after merge and never checks out or executes code from the fork branch itself — it only reads \`merge_commit_sha\`, which is already on the base repo.

## Test plan
- [x] Merge a fork-originated PR touching \`packages/**\` and confirm the sync job succeeds and opens a follow-up PR on \`nTopology/Utilities\`.